### PR TITLE
Double as source

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,19 @@
 const forEach = operation => source => {
-  let talkback;
+  let sourceTalkback;
+  let sinkTalkback;
   source(0, (t, d) => {
-    if (t === 0) talkback = d;
+    if (t === 0) sourceTalkback = d;
     if (t === 1) operation(d);
-    if (t === 1 || t === 0) talkback(1);
+    if (t === 1 || t === 0) sourceTalkback(1);
+    if (t !== 0 && sinkTalkback) sinkTalkback(t, d);
   });
+  return (start, sink) => {
+    if (start !== 0) return;
+    sinkTalkback = sink;
+    sink(0, (t, d) => {
+      if (t === 2) sinkTalkback = null;
+    });
+  }
 };
 
 module.exports = forEach;

--- a/test.js
+++ b/test.js
@@ -108,3 +108,67 @@ test('it observes an async finite listenable source', t => {
   }, 700);
 });
 
+test('it passes data between source and a downstream sink', t => {
+  let history = [];
+  const report = (name,dir,t,d) => t !== 0 && d !== undefined && history.push([name,dir,t,d]);
+
+  const source = makeMockCallbag('source', report, true);
+  const middle = forEach(x => history.push(['middle', 1, x]));
+  const sink = makeMockCallbag('sink', report);
+
+  middle(source)(0, sink);
+
+  source.emit(1, 'foo');
+  source.emit(1, 'bar');
+  sink.emit(1, 'baz');
+  source.emit(2, 'errormsg');
+
+  t.deepEqual(history, [
+    ['middle', 1, 'foo'],
+    ['sink', 'fromUp', 1, 'foo'],
+    ['middle', 1, 'bar'],
+    ['sink', 'fromUp', 1, 'bar'],
+    ['sink', 'fromUp', 2, 'errormsg']
+  ], 'forEach passed data downstream as expected');
+
+  t.end();
+});
+
+test('it stops passing data on if sink terminates', t => {
+  let history = [];
+  const report = (name,dir,t,d) => t !== 0 && d !== undefined && history.push([name,dir,t,d]);
+
+  const source = makeMockCallbag('source', report, true);
+  const middle = forEach(x => history.push(['middle', 1, x]));
+  const sink = makeMockCallbag('sink', report);
+
+  middle(source)(0, sink);
+
+  source.emit(1, 'foo');
+  sink.emit(2);
+  source.emit(1, 'bar');
+
+  t.deepEqual(history, [
+    ['middle', 1, 'foo'],
+    ['sink', 'fromUp', 1, 'foo'],
+    ['middle', 1, 'bar'],
+  ], 'sink doesnt receive more messages after termination');
+
+  t.end();
+});
+
+function makeMockCallbag(name, report=()=>{}, isSource) {
+  let talkback;
+  let mock = (t, d) => {
+    if (t === 0){
+      talkback = d;
+      if (isSource) talkback(0, (st, sd) => report(name, 'fromDown', st, sd));
+    }
+    report(name, 'fromUp', t, d);
+  };
+  mock.emit = (t, d) => {
+    if (!talkback) throw new Error(`Can't emit from ${name} before anyone has connected`);
+    talkback(t, d);
+  };
+  return mock;
+}


### PR DESCRIPTION
This PR makes `forEach` be both a sink and a potential source, should you want to keep plugging stuff in downstream. You might for example want to put it in the middle of a pipe chain to log out stuff for debugging purposes.

Some spots of bad conscience:

* this works poorly with synchronous things like `fromIter`. A `fromIter` source will be fully consumed by `forEach` before the downstream stuff can even connect.
* readme isn't updated.
* I had trouble conforming the new tests to the existing ones, so in the end I simply didn't :P
